### PR TITLE
JDK和Maven安装脚本，以及项目打包脚本提交

### DIFF
--- a/scripts/jdk/jdk_install.sh
+++ b/scripts/jdk/jdk_install.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+
+#工作目录
+work_home="/home/li-dongdong"
+#OpenJDK压缩包位置
+jdkTargz="${work_home}/downloads/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz"
+#jdk安装目录
+jdk_package="${work_home}/apps/"
+
+
+
+
+set_jdk(){
+	# 查询是否有jdk.tar.gz
+	if [ -e $jdkTargz ];
+	then
+	echo "— — 存在jdk压缩包 — —"
+		
+		echo "正在解压jdk压缩包..."
+		tar -zxvf ${jdkTargz} -C ${jdk_package}
+
+    cd $jdk_package
+		echo "正在建立jdk软链接..."
+		ln -sf jdk-17.0.9+9 jdk
+		
+		echo "---------------------------------"
+		echo "---------------------------------"
+		echo "--------JDKInstall,OK!-------------"
+		echo "---配置版本信息如下：---"
+	    jdk/bin/java -version
+		
+		
+	else
+		echo "未检测到安装包"
+		exit 1
+	fi
+}
+
+####main
+set_jdk

--- a/scripts/jdk/jdk_install.sh
+++ b/scripts/jdk/jdk_install.sh
@@ -1,36 +1,29 @@
 #!/bin/bash
 
-
 #工作目录
 work_home="/home/li-dongdong"
+
 #OpenJDK压缩包位置
 jdkTargz="${work_home}/downloads/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz"
+
 #jdk安装目录
 jdk_package="${work_home}/apps/"
-
-
-
 
 set_jdk(){
 	# 查询是否有jdk.tar.gz
 	if [ -e $jdkTargz ];
 	then
 	echo "— — 存在jdk压缩包 — —"
-		
-		echo "正在解压jdk压缩包..."
-		tar -zxvf ${jdkTargz} -C ${jdk_package}
-
+	echo "正在解压jdk压缩包..."
+	tar -zxvf ${jdkTargz} -C ${jdk_package}
     cd $jdk_package
-		echo "正在建立jdk软链接..."
-		ln -sf jdk-17.0.9+9 jdk
-		
-		echo "---------------------------------"
-		echo "---------------------------------"
-		echo "--------JDKInstall,OK!-------------"
-		echo "---配置版本信息如下：---"
-	    jdk/bin/java -version
-		
-		
+	echo "正在建立jdk软链接..."
+	ln -sf jdk-17.0.9+9 jdk
+	echo "---------------------------------"
+	echo "---------------------------------"
+	echo "--------JDKInstall,OK!-------------"
+	echo "---配置版本信息如下：---"
+	jdk/bin/java -version
 	else
 		echo "未检测到安装包"
 		exit 1

--- a/scripts/jdk/openjdk17_install.sh
+++ b/scripts/jdk/openjdk17_install.sh
@@ -16,10 +16,8 @@ if [ "$OS_ARCH" == "x86_64" ];
    then
       https://github.com/AdoptOpenJDK/semeru17-binaries/releases/download/jdk-17.0.9%2B9_openj9-0.41.0/ibm-semeru-open-jdk_x64_linux_17.0.9_9_openj9-0.41.0.tar.gz
       tar -zxvf ibm-semeru-open-jdk_x64_linux_17.0.9_9_openj9-0.41.0.tar.gz
-
       echo -n " - JDK Installtaion =>"
       ln -sfn ibm-semeru-open-jdk_x64_linux_17.0.9_9_openj9-0.41.0 jdk
-
       echo "OK!!"
    else
       echo "This OS version not supported"

--- a/scripts/maven/maven_install.sh
+++ b/scripts/maven/maven_install.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+#工作目录
+work_home="/home/li-dongdong"
+#Maven安装包
+mavenTargz="${work_home}/downloads/maven-3.9.6-bin.tar.gz"
+#Maven下载位置
+maven="${work_home}/apps/"
+#Maveb配置文件位置
+maven_setting="${maven}/maven-3.9.6/conf/settings.xml"
+#自定义Maven仓库地址
+maven_repo="${maven}/maven-3.9.6/maven-repo"
+
+SED_PATH="/usr/bin/sed"
+EXPR_PATH="/usr/bin/expr"
+
+
+
+
+set_maven(){
+		# 查询是否有maven.tar.gz安装包
+	if [ -e $mavenTargz ];
+	then
+
+	echo "— — 存在maven压缩包 — —"
+		
+		echo "正在解压maven压缩包..."
+		tar -zxvf ${mavenTargz} -C ${maven}
+		echo "---------------------------------"
+		echo "Maven解压已完成..."
+		cd $maven
+		echo "----正在建立软链接--------"
+        mv apache-maven-3.9.6 maven-3.9.6
+        ln -sf maven-3.9.6 maven
+		
+		set_mirror
+		set_repo
+	else
+		echo "未检测到安装包"
+		exit 1
+	fi
+}
+
+set_repo(){
+	grep_path=/usr/bin/grep
+	cut_path=/usr/bin/cut
+	echo "正在配置maven仓库..."
+	echo "---------------------------------"
+    mkdir -p $maven_repo
+    repo_num=$(${grep_path} -n "</localRepository>" "${maven_setting}" | ${cut_path} -f1 -d':')
+    $SED_PATH -i "$(($repo_num + 1))a\\  \\<localRepository\\>\\$maven_repo\\<\\/localRepository\\>" "$maven_setting"
+    echo "maven仓库配置完成!配置路径为：${maven_repo}"
+	echo "---------------------------------"
+    echo "--请手动执行"mvn -v"检查maven信息--"
+}
+
+set_mirror(){
+	echo "正在配置阿里云镜像..."
+    echo "---------------------------------"
+        
+    num=$($SED_PATH -n -e "/<mirrors>/=" "$maven_setting")
+    $SED_PATH -i "${num}a\\    \\<mirror\\>" "$maven_setting"
+    $SED_PATH -i "$(($num + 1))a\\      \\<id\\>aliyunmaven\\<\\/id\\>" "$maven_setting"
+    $SED_PATH -i "$(($num + 2))a\\      \\<mirrorOf\\>*\\<\\/mirrorOf\\>" "$maven_setting"
+    $SED_PATH -i "$(($num + 3))a\\      \\<name\\>阿里云公共仓库\\<\\/name\\>" "$maven_setting"
+    $SED_PATH -i "$(($num + 4))a\\      \\<url\\>https://maven.aliyun.com/repository/public\\<\\/url\\>" "$maven_setting"
+    $SED_PATH -i "$(($num + 5))a\\    \\<\\/mirror\\>" "$maven_setting"
+    echo "阿里云镜像配置完成"
+	echo "---------------------------------"
+}
+
+set_maven
+

--- a/scripts/maven/maven_install.sh
+++ b/scripts/maven/maven_install.sh
@@ -37,7 +37,7 @@ set_maven(){
 }
 
 set_repo(){
-	echo "正在配置maven仓库..."
+    echo "正在配置maven仓库..."
 	echo "---------------------------------"
     mkdir -p $maven_repo
     repo_num=$(grep -n "</localRepository>" "${maven_setting}" | cut -f1 -d':')

--- a/scripts/maven/maven_install.sh
+++ b/scripts/maven/maven_install.sh
@@ -2,37 +2,32 @@
 
 #工作目录
 work_home="/home/li-dongdong"
+
 #Maven安装包
-mavenTargz="${work_home}/downloads/maven-3.9.6-bin.tar.gz"
+mavenTarGz="${work_home}/downloads/apache-maven-3.9.6-bin.tar.gz"
+
 #Maven下载位置
 maven="${work_home}/apps/"
+
 #Maveb配置文件位置
 maven_setting="${maven}/maven-3.9.6/conf/settings.xml"
+
 #自定义Maven仓库地址
 maven_repo="${maven}/maven-3.9.6/maven-repo"
 
-SED_PATH="/usr/bin/sed"
-EXPR_PATH="/usr/bin/expr"
-
-
-
-
 set_maven(){
-		# 查询是否有maven.tar.gz安装包
-	if [ -e $mavenTargz ];
+	# 查询是否有maven.tar.gz安装包
+	if [ -e $mavenTarGz ]
 	then
-
-	echo "— — 存在maven压缩包 — —"
-		
-		echo "正在解压maven压缩包..."
-		tar -zxvf ${mavenTargz} -C ${maven}
+	    echo "— — 存在maven压缩包 — —"
+        echo "正在解压maven压缩包..."
+		tar -zxvf ${mavenTarGz} -C ${maven}
 		echo "---------------------------------"
 		echo "Maven解压已完成..."
 		cd $maven
 		echo "----正在建立软链接--------"
         mv apache-maven-3.9.6 maven-3.9.6
         ln -sf maven-3.9.6 maven
-		
 		set_mirror
 		set_repo
 	else
@@ -42,13 +37,11 @@ set_maven(){
 }
 
 set_repo(){
-	grep_path=/usr/bin/grep
-	cut_path=/usr/bin/cut
 	echo "正在配置maven仓库..."
 	echo "---------------------------------"
     mkdir -p $maven_repo
-    repo_num=$(${grep_path} -n "</localRepository>" "${maven_setting}" | ${cut_path} -f1 -d':')
-    $SED_PATH -i "$(($repo_num + 1))a\\  \\<localRepository\\>\\$maven_repo\\<\\/localRepository\\>" "$maven_setting"
+    repo_num=$(grep -n "</localRepository>" "${maven_setting}" | cut -f1 -d':')
+    sed -i "$((${repo_num} + 1))a\\  \\<localRepository\\>\\$maven_repo\\<\\/localRepository\\>" "$maven_setting"
     echo "maven仓库配置完成!配置路径为：${maven_repo}"
 	echo "---------------------------------"
     echo "--请手动执行"mvn -v"检查maven信息--"
@@ -57,14 +50,13 @@ set_repo(){
 set_mirror(){
 	echo "正在配置阿里云镜像..."
     echo "---------------------------------"
-        
-    num=$($SED_PATH -n -e "/<mirrors>/=" "$maven_setting")
-    $SED_PATH -i "${num}a\\    \\<mirror\\>" "$maven_setting"
-    $SED_PATH -i "$(($num + 1))a\\      \\<id\\>aliyunmaven\\<\\/id\\>" "$maven_setting"
-    $SED_PATH -i "$(($num + 2))a\\      \\<mirrorOf\\>*\\<\\/mirrorOf\\>" "$maven_setting"
-    $SED_PATH -i "$(($num + 3))a\\      \\<name\\>阿里云公共仓库\\<\\/name\\>" "$maven_setting"
-    $SED_PATH -i "$(($num + 4))a\\      \\<url\\>https://maven.aliyun.com/repository/public\\<\\/url\\>" "$maven_setting"
-    $SED_PATH -i "$(($num + 5))a\\    \\<\\/mirror\\>" "$maven_setting"
+    num=$(sed -n -e "/<mirrors>/=" "$maven_setting")
+    sed -i "${num}a\\    \\<mirror\\>" "$maven_setting"
+    sed -i "$(($num + 1))a\\      \\<id\\>aliyunmaven\\<\\/id\\>" "$maven_setting"
+    sed -i "$(($num + 2))a\\      \\<mirrorOf\\>*\\<\\/mirrorOf\\>" "$maven_setting"
+    sed -i "$(($num + 3))a\\      \\<name\\>阿里云公共仓库\\<\\/name\\>" "$maven_setting"
+    sed -i "$(($num + 4))a\\      \\<url\\>https://maven.aliyun.com/repository/public\\<\\/url\\>" "$maven_setting"
+    sed -i "$(($num + 5))a\\    \\<\\/mirror\\>" "$maven_setting"
     echo "阿里云镜像配置完成"
 	echo "---------------------------------"
 }

--- a/scripts/package/appdemoe-be_package.sh
+++ b/scripts/package/appdemoe-be_package.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# 工作目录
+work_dir="/home/li-dongdong"
+
+# 项目目录
+work_home="${work_dir}/repository/appdemo-be"
+
+# maven mvn命令执行脚本
+wrapper="${work_home}/scripts/package"
+
+# 存放jar包的目录
+jar_home="${work_dir}/deploy/appdemo-be"
+
+# 源码目录
+code_home="${work_dir}/repository"
+
+# Git仓库地址
+git_repo="https://github.com/175T/appdemo-be.git"
+
+# 排除的文件，可以减少cp命令的开销
+excludes=(*.log *.tmp /path/to/exclude)
+
+# 打包和部署函数
+package_and_deploy() {
+    local service_name=$1
+    local jar_name=$2
+    local target_dir="${work_home}/${service_name}/target"
+    local jar_path="${target_dir}/${jar_name}"
+
+    if [ -f "$jar_path" ]; then
+        cp -rf "$jar_path" $jar_home/
+        echo "--- $service_name --- OK! ---"
+    else
+        echo "Error: ${jar_path} does not exist."
+        exit 1
+    fi
+}
+
+# 主函数
+main() {
+    if [ -d "$work_home" ]; then
+        echo "— — 工作目录存在 — —"
+        cd "$work_home"
+        echo "— — 正在更新项目... — —"
+        git pull origin master
+        echo "— — — — 项目已更新— — — —"
+    else
+        echo "未检测到需要打包的api"
+        echo "正在为你拉取最新的项目"
+        git clone $git_repo "$code_home"
+        echo "— — 项目已克隆— — — —"
+    fi
+
+    echo "----正在执行打包命令...-----------"
+    $wrapper/maven-wrapper.sh clean package -Dmaven.test.skip=true -Dcheckstyle.skip=true
+    echo "所有项目打包完成"
+
+    mkdir -p "$jar_home"
+
+    # 这里根据实际的jar包名和位置进行拷贝
+    package_and_deploy "admin-api" "admin-api.jar"
+    package_and_deploy "common" "common-1.0-SNAPSHOT.jar"
+    package_and_deploy "portal-api" "portal-api.jar"
+    package_and_deploy "repository" "repository-1.0-SNAPSHOT.jar"
+    package_and_deploy "service" "service-1.0-SNAPSHOT.jar"
+    package_and_deploy "task" "task.jar"
+
+    echo "所有jar包均已存放至部署目录"
+}
+
+main "$@"

--- a/scripts/package/maven-wrapper.sh
+++ b/scripts/package/maven-wrapper.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# 替换下面的路径为你机器上对应的实际路径
+JAVA_HOME="/home/li-dongdong/apps/jdk"
+MAVEN_HOME="/home/li-dongdong/apps/maven"
+
+# 为Java和Maven执行指定使用的路径
+PATH=$JAVA_HOME/bin:$MAVEN_HOME/bin:$PATH
+
+# 执行Maven命令，$@表示传递给脚本的所有参数
+mvn $@


### PR DESCRIPTION
## 新增内容

### JDK安装脚本

>script/jdk/jdk_install.sh

### Maven安装脚本

> script/maven/maven_install.sh

### package脚本

> script/package/appdemo-be_package.sh

> script/package/maven-wrapper.sh    

注：使用`maven-wrapper.sh`   是因为环境变量是没有配置到系统文件`etc/.profile`或者子用户组`~/.bashrc`

使用这种方式指定`JAVA_HOME`和`MAVEN_HOME`来替代`mvn`命令，在appdemo-be_package.sh中可以看到打包命令就是以这种方式执行的。

```shell
# maven mvn命令执行脚本
wrapper="${work_home}/scripts/package"
$wrapper/maven-wrapper.sh clean package -Dmaven.test.skip=true -Dcheckstyle.skip=true
```

